### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Flash-ANSR are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-06-27
+
+A small maintenance release.
+
+### Changed
+- Default Weights & Biases logging mode for training is now `disabled` (CLI `--mode` and
+  `Trainer.train(..., wandb_mode=...)`). Training works out of the box without a W&B account or
+  network; pass `--mode online` (or `wandb_mode="online"`) to enable logging.
+
+### Internal
+- Moved the `simplify="sympy"` timeout helper to a dependency-light leaf module
+  (`flash_ansr.utils.sympy_timeout`); the model and skeleton pool now import it from there. No
+  behaviour change; this decouples the helper from the data/sampling module ahead of a future
+  package split.
+- The `simplify="sympy"` path now raises a clear, actionable `ImportError` (pointing at
+  `pip install flash-ansr[sympy]`) if `sympy` is ever unavailable. In practice `sympy` ships as a
+  transitive dependency of `torch`, so this is defensive only.
+
 ## [0.6.0] - 2026-06-26
 
 A scope-focused release: the evaluation framework, comparison baselines, and benchmarks are split

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dynamic = ["dependencies"]
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 

--- a/src/flash_ansr/__main__.py
+++ b/src/flash_ansr/__main__.py
@@ -45,7 +45,7 @@ def main(argv: str = None) -> None:
     train_parser.add_argument('--project', type=str, default='neural-symbolic-regression', help='Name of the wandb project')
     train_parser.add_argument('--entity', type=str, default='psaegert', help='Name of the wandb entity')
     train_parser.add_argument('--name', type=str, default=None, help='Name of the wandb run')
-    train_parser.add_argument('--mode', type=str, default='online', help='Mode for wandb logging')
+    train_parser.add_argument('--mode', type=str, default='disabled', help="Mode for wandb logging ('online', 'offline', or 'disabled'; default disabled — pass --mode online to log)")
     train_parser.add_argument('--resume-from', type=str, default=None, help='Path to a checkpoint directory to resume from')
     train_parser.add_argument('--resume-step', type=int, default=None, help='Override the inferred resume step when resuming')
 

--- a/src/flash_ansr/expressions/skeleton_pool.py
+++ b/src/flash_ansr/expressions/skeleton_pool.py
@@ -17,6 +17,7 @@ from simplipy.utils import explicit_constant_placeholders, numbers_to_constant
 
 from flash_ansr.utils.config_io import load_config, save_config
 from flash_ansr.utils.paths import substitute_root_path
+from flash_ansr.utils.sympy_timeout import _sympy_simplify_with_timeout
 from simplipy.utils import codify
 from flash_ansr.expressions.prior_factory import build_prior_callable
 from flash_ansr.expressions.holdout import HoldoutManager
@@ -27,76 +28,6 @@ from flash_ansr.expressions.token_ops import flatten_nested_list
 
 class NoValidSampleFoundError(Exception):
     pass
-
-
-def _sympy_simplify_call(expr_str: str) -> str:
-    """Run sympy.simplify (called in a thread to allow timeout)."""
-    from sympy import simplify as _sp_simplify, parse_expr as _sp_parse  # noqa: delayed import
-    expr = _sp_parse(expr_str)
-    result = _sp_simplify(expr, ratio=1)
-    return str(result)
-
-
-def _sympy_simplify_with_timeout(expr_str: str, timeout_seconds: float = 1.0) -> tuple[str, float] | None:
-    """Return (simplified_str, elapsed) or None on timeout / error.
-
-    Uses os.fork() so that hung SymPy calls can be killed via SIGKILL,
-    preventing zombie-thread accumulation that degrades performance.
-    """
-    import time
-    import signal
-    import select
-    import sympy  # noqa: F401 – ensure imported before fork
-
-    r_fd, w_fd = os.pipe()
-    start = time.time()
-    pid = os.fork()
-
-    if pid == 0:
-        # ── child process ──
-        os.close(r_fd)
-        try:
-            result = _sympy_simplify_call(expr_str)
-            os.write(w_fd, result.encode('utf-8'))
-        except Exception:
-            pass
-        finally:
-            os.close(w_fd)
-            os._exit(0)
-
-    # ── parent process ──
-    os.close(w_fd)
-
-    ready, _, _ = select.select([r_fd], [], [], timeout_seconds)
-    elapsed = time.time() - start
-
-    if ready:
-        chunks = []
-        while True:
-            chunk = os.read(r_fd, 4096)
-            if not chunk:
-                break
-            chunks.append(chunk)
-        os.close(r_fd)
-        data = b''.join(chunks)
-        try:
-            os.waitpid(pid, 0)
-        except ChildProcessError:
-            pass
-        if data:
-            return (data.decode('utf-8'), elapsed)
-        return None
-    else:
-        os.close(r_fd)
-        try:
-            os.kill(pid, signal.SIGKILL)
-        except OSError:
-            pass
-        try:
-            os.waitpid(pid, 0)
-        except ChildProcessError:
-            pass
-        return None
 
 
 def _constantify_skeleton(skeleton: list[str]) -> list[str]:

--- a/src/flash_ansr/model/flash_ansr_model.py
+++ b/src/flash_ansr/model/flash_ansr_model.py
@@ -18,7 +18,7 @@ from flash_ansr.model.encoders import SetTransformer
 from flash_ansr.model.decoders import TransformerDecoder
 from flash_ansr.model.decoders.static_kv import StaticKVCache
 from flash_ansr.decoding.mcts import MonteCarloTreeSearch, MCTSConfig, PolicyStep
-from flash_ansr.expressions.skeleton_pool import _sympy_simplify_with_timeout
+from flash_ansr.utils.sympy_timeout import _sympy_simplify_with_timeout
 
 
 ValueFunction: TypeAlias = Callable[[Tuple[int, ...]], float]

--- a/src/flash_ansr/train/train.py
+++ b/src/flash_ansr/train/train.py
@@ -440,7 +440,7 @@ class Trainer:
             validate_interval: int | None = None,
             validate_size: int | None = None,
             validate_batch_size: int = 128,
-            wandb_mode: Literal['online', 'offline', 'disabled'] = 'online',
+            wandb_mode: Literal['online', 'offline', 'disabled'] = 'disabled',
             wandb_watch_log: Literal['gradients', 'parameters', 'all'] | None = None,
             wandb_watch_log_freq: int = 1000,
             preprocess_in_worker: bool | None = None,
@@ -476,8 +476,9 @@ class Trainer:
             Maximum number of validation samples, if limited.
         validate_batch_size : int, default=128
             Batch size to use during validation.
-        wandb_mode : {'online', 'offline', 'disabled'}, default='online'
-            W&B initialisation mode.
+        wandb_mode : {'online', 'offline', 'disabled'}, default='disabled'
+            W&B initialisation mode. Defaults to ``'disabled'`` so a fresh install trains without
+            requiring a W&B account or network; pass ``'online'`` to enable logging.
         wandb_watch_log : {'gradients', 'parameters', 'all'} or None, optional
             W&B ``watch`` setting controlling what to log.
         wandb_watch_log_freq : int, default=1000

--- a/src/flash_ansr/utils/sympy_timeout.py
+++ b/src/flash_ansr/utils/sympy_timeout.py
@@ -1,0 +1,89 @@
+"""Timeout-guarded SymPy simplification, isolated as a dependency-light leaf utility.
+
+This module deliberately depends only on the standard library plus a *lazily*-imported
+``sympy`` so that importing it does NOT pull in the data/sampling stack. It backs the
+optional ``simplify == 'sympy'`` canonicalization mode (a secondary canonicaliser on top
+of the primary simplipy engine). ``sympy`` is an optional extra::
+
+    pip install flash-ansr[sympy]
+"""
+import os
+
+
+def _sympy_simplify_call(expr_str: str) -> str:
+    """Run sympy.simplify (called in a forked child to allow timeout)."""
+    from sympy import simplify as _sp_simplify, parse_expr as _sp_parse  # noqa: delayed import
+    expr = _sp_parse(expr_str)
+    result = _sp_simplify(expr, ratio=1)
+    return str(result)
+
+
+def _sympy_simplify_with_timeout(expr_str: str, timeout_seconds: float = 1.0) -> tuple[str, float] | None:
+    """Return (simplified_str, elapsed) or None on timeout / error.
+
+    Uses os.fork() so that hung SymPy calls can be killed via SIGKILL,
+    preventing zombie-thread accumulation that degrades performance.
+
+    Requires the optional ``sympy`` dependency (``pip install flash-ansr[sympy]``);
+    raises a clear ``ImportError`` with that hint if it is missing.
+    """
+    import time
+    import signal
+    import select
+    try:
+        import sympy  # noqa: F401 – ensure imported before fork
+    except ImportError as exc:  # pragma: no cover - only hit without the [sympy] extra
+        raise ImportError(
+            "The simplify=='sympy' mode requires the optional 'sympy' dependency. "
+            "Install it with: pip install flash-ansr[sympy]"
+        ) from exc
+
+    r_fd, w_fd = os.pipe()
+    start = time.time()
+    pid = os.fork()
+
+    if pid == 0:
+        # ── child process ──
+        os.close(r_fd)
+        try:
+            result = _sympy_simplify_call(expr_str)
+            os.write(w_fd, result.encode('utf-8'))
+        except Exception:
+            pass
+        finally:
+            os.close(w_fd)
+            os._exit(0)
+
+    # ── parent process ──
+    os.close(w_fd)
+
+    ready, _, _ = select.select([r_fd], [], [], timeout_seconds)
+    elapsed = time.time() - start
+
+    if ready:
+        chunks = []
+        while True:
+            chunk = os.read(r_fd, 4096)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        os.close(r_fd)
+        data = b''.join(chunks)
+        try:
+            os.waitpid(pid, 0)
+        except ChildProcessError:
+            pass
+        if data:
+            return (data.decode('utf-8'), elapsed)
+        return None
+    else:
+        os.close(r_fd)
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+        try:
+            os.waitpid(pid, 0)
+        except ChildProcessError:
+            pass
+        return None


### PR DESCRIPTION
A small maintenance release.

### Changed
- Default Weights & Biases logging mode for training is now `disabled` (CLI `--mode` and `Trainer.train(..., wandb_mode=...)`). Training works out of the box without a W&B account or network; pass `--mode online` (or `wandb_mode="online"`) to enable logging.

### Internal
- Moved the `simplify="sympy"` timeout helper to a dependency-light leaf module (`flash_ansr.utils.sympy_timeout`); the model and skeleton pool import it from there. No behaviour change; decouples the helper from the data/sampling module ahead of a future package split.
- The `simplify="sympy"` path now raises a clear, actionable `ImportError` pointing at `pip install flash-ansr[sympy]` if `sympy` is ever unavailable. In practice `sympy` ships transitively with `torch`, so this is defensive only.

Validation: pytest 588 passed / 2 skipped; clean-venv install + import + `simplify="sympy"` mode verified; wheel `twine check` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)