### PR TITLE
docs: repoint data-prep docs/scripts off the dropped data CLI (0.7)

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -20,28 +20,35 @@
 Produces checkpoints under `models/ansr-models/test/` with `model.yaml`, `tokenizer.yaml`, and `state_dict.pt`.
 
 ## Helper scripts
-- `./scripts/import_test_sets.sh`: import benchmark skeletons once so training excludes evaluation holdouts.
-- `./scripts/generate_validation_set.sh <config>`: create held-out skeleton pools matching your bundle.
+- `./scripts/generate_validation_set.sh <config>`: create a held-out validation skeleton pool matching your bundle (wraps `symbolic_data.SkeletonPool`).
+- `./scripts/generate_test_set.sh <config>`: create a test-set skeleton pool from `configs/test_set/<config>/`.
+- `./scripts/import_test_sets.sh`: **pending symbolic-data 0.2; currently prints a notice and exits 1.** Once the data-layer ingest CLI ships it will build a holdout pool from a raw benchmark spec (so training excludes evaluation skeletons); see step 1 below for the interim.
 - `./scripts/train.sh <config>`: convenience wrapper to launch training with the bundle.
 
+> Pool generation moved out of flash-ansr in 0.7: the model package consumes skeleton pools and no longer ships a data CLI (the removed `generate-skeleton-pool` / `import-data` / `filter-skeleton-pool` / `split-skeleton-pool` subcommands). The pool/sampling API lives in [symbolic-data](https://github.com/psaegert/symbolic-data) (a flash-ansr dependency); a first-class `symbolic-data` CLI is planned for symbolic-data 0.2. The helper scripts and `configs/` bundles referenced here live in the repository, not the PyPI wheel; clone the repo to use them.
+
 ## Full training workflow
-1. **Import test sets**: Adjust and run `./scripts/import_test_sets.sh` to import test sets. The data generating processes during training will exclude these skeletons to ensure fair evaluation.
+1. **Import test sets** (training-time decontamination): training excludes the skeletons listed under `holdout_pools:` in your `skeleton_pool_*.yaml`, so the data-generating process never samples a benchmark test skeleton. Building that holdout pool from a raw benchmark spec (the old `import_test_sets.sh`) needs the data-ingest tooling that moved to [symbolic-data](https://github.com/psaegert/symbolic-data) and is **pending symbolic-data 0.2**: no interim command reproduces it (`generate_test_set.sh` samples *random* skeletons, not the benchmark equations). Until then: if you already have a benchmark holdout pool on disk, point `holdout_pools:` at it (this is what the shipped `configs/v23.*` bundles do); otherwise train with `holdout_pools: []`, which is fine for non-benchmark use, but note that benchmark eval numbers (e.g. FastSRB/Feynman) will be contaminated until you can decontaminate. (`symbolic_data.load_benchmark('fastsrb')` exposes the FastSRB benchmark for *evaluation* via srbf, not training-holdout exclusion.)
 2. **Configure skeleton pools and datasets**: Adjust the `skeleton_pool_*.yaml` and `dataset_*.yaml` files inside your chosen config bundle to set operator priors, expression depths, and data sampling strategies.
-3. **Prepare held out skeleton pools** (optional if reusing shipped ones):
-    ```bash
-    flash_ansr generate-skeleton-pool \
-    -c "./configs/my_model/skeleton_pool_val.yaml" \
-    -o "./data/ansr-data/my_model/skeleton_pool_val" \
-    -s 1000 -v  # 1000 skeletons for validation
+3. **Prepare held out skeleton pools** (optional if reusing shipped ones): generate a pool with the `symbolic-data` Python API, or use `./scripts/generate_validation_set.sh <config>`. Run from the project root so the relative paths resolve:
+    ```python
+    from symbolic_data import SkeletonPool
+
+    config = "./configs/my_model/skeleton_pool_val.yaml"
+    pool = SkeletonPool.from_config(config)
+    pool.create(size=1000, verbose=True)  # 1000 skeletons for validation
+    pool.save("./data/ansr-data/my_model/skeleton_pool_val", config=config)
     ```
 4. **Launch training**:
     ```bash
-    flash_ansr train
-    -c "./configs/my_model/train.yaml"
-    -o "./models/ansr-models/my_model"
-    -v
-    -ci 250000  # Checkpoint every 250k steps
-    -vi 10000  # Validate every 10k steps
+    # -ci/--checkpoint-interval: checkpoint every 250k steps
+    # -vi/--validate-interval: validate every 10k steps
+    flash_ansr train \
+    -c "./configs/my_model/train.yaml" \
+    -o "./models/ansr-models/my_model" \
+    -v \
+    -ci 250000 \
+    -vi 10000
     ```
 5. **Logging**: Enable/disable W&B logging via `wandb_mode` inside the config.
 6. **Resume**: Continue from any checkpoint directory using `--resume-from` (optionally `--resume-step` when the step cannot be inferred).

--- a/scripts/generate_test_set.sh
+++ b/scripts/generate_test_set.sh
@@ -1,11 +1,27 @@
-# !/bin/bash
+#!/bin/bash
+# Generate a test skeleton pool for a config bundle (under configs/test_set/<CONFIG>/).
+#
+# Pool generation lives in the symbolic-data data layer (`symbolic_data.SkeletonPool`):
+# flash-ansr 0.7 consumes skeleton pools and no longer ships a data CLI. A first-class
+# `symbolic-data` CLI is planned for symbolic-data 0.2; until then this wraps the Python API.
+# Run from the project root so the relative config/output paths resolve.
+set -euo pipefail
 
-# Check if an argument was passed
-if [ $# -eq 0 ]; then
-    echo "Usage: run.sh <CONFIG>"
+if [ $# -lt 1 ]; then
+    echo "Usage: generate_test_set.sh <CONFIG>"
     exit 1
-else
-    CONFIG=$1
 fi
+CONFIG="$1"
 
-flash_ansr generate-skeleton-pool -c {{ROOT}}/configs/test_set/${CONFIG}/skeleton_pool.yaml -o {{ROOT}}/data/ansr-data/test_set/${CONFIG}/skeleton_pool -s 1000 -v
+python - "$CONFIG" <<'PY'
+import sys
+from symbolic_data import SkeletonPool
+
+config = f"./configs/test_set/{sys.argv[1]}/skeleton_pool.yaml"
+output = f"./data/ansr-data/test_set/{sys.argv[1]}/skeleton_pool"
+
+pool = SkeletonPool.from_config(config)
+pool.create(size=1000, verbose=True)
+pool.save(output, config=config)
+print(f"Saved test skeleton pool to {output}")
+PY

--- a/scripts/generate_validation_set.sh
+++ b/scripts/generate_validation_set.sh
@@ -1,18 +1,27 @@
-# !/bin/bash
+#!/bin/bash
+# Generate a held-out validation skeleton pool for a config bundle.
+#
+# Pool generation lives in the symbolic-data data layer (`symbolic_data.SkeletonPool`):
+# flash-ansr 0.7 consumes skeleton pools and no longer ships a data CLI. A first-class
+# `symbolic-data` CLI is planned for symbolic-data 0.2; until then this wraps the Python API.
+# Run from the project root so the relative config/output paths resolve.
+set -euo pipefail
 
-# Check if an argument was passed
-if [ $# -eq 0 ]; then
-    echo "Usage: run.sh <CONFIG>"
+if [ $# -lt 1 ]; then
+    echo "Usage: generate_validation_set.sh <CONFIG>"
     exit 1
-else
-    CONFIG=$1
 fi
+CONFIG="$1"
 
-# If two arguments were passed, store the second one in MODEL, otherwise set MODEL=CONFIG
-if [ $# -eq 2 ]; then
-    MODEL=$2
-else
-    MODEL=$CONFIG
-fi
+python - "$CONFIG" <<'PY'
+import sys
+from symbolic_data import SkeletonPool
 
-flash_ansr generate-skeleton-pool -c {{ROOT}}/configs/${CONFIG}/skeleton_pool_val.yaml -o {{ROOT}}/data/ansr-data/${CONFIG}/skeleton_pool_val -s 1000 -v
+config = f"./configs/{sys.argv[1]}/skeleton_pool_val.yaml"
+output = f"./data/ansr-data/{sys.argv[1]}/skeleton_pool_val"
+
+pool = SkeletonPool.from_config(config)
+pool.create(size=1000, verbose=True)  # 1000 skeletons for validation
+pool.save(output, config=config)
+print(f"Saved validation skeleton pool to {output}")
+PY

--- a/scripts/import_test_sets.sh
+++ b/scripts/import_test_sets.sh
@@ -1,6 +1,27 @@
-flash_ansr import-data -i "{{ROOT}}/data/ansr-data/test_set/fastsrb/expressions.yaml" -p "fastsrb" -e "dev_7-3" -b "{{ROOT}}/configs/test_set/skeleton_pool.yaml" -o "{{ROOT}}/data/ansr-data/test_set/fastsrb/skeleton_pool" -v
+#!/bin/bash
+# Import benchmark equations into a holdout skeleton pool (training-time decontamination).
+#
+# STATUS: pending symbolic-data 0.2.
+#
+# This step parsed a raw benchmark spec (the FastSRB `expressions.yaml`, or CSV sets such as
+# Feynman/Nguyen) into a skeleton pool, which training then referenced under `holdout_pools:` so
+# the data-generating process never samples a test skeleton. The raw-spec ingest (ParserFactory)
+# was part of flash-ansr's data CLI, which moved to the symbolic-data data layer in flash-ansr 0.7.
+# symbolic-data 0.1.0 ships the data API (SkeletonPool / sampling) but NOT yet the ingest CLI;
+# that lands in symbolic-data 0.2.
+#
+# In the meantime there is NO interim command that rebuilds a benchmark holdout pool:
+#   * If you already have a benchmark holdout pool on disk, point holdout_pools: at it, e.g.
+#       holdout_pools: ["./data/ansr-data/test_set/fastsrb/skeleton_pool"]
+#     (this is what the shipped configs/v23.* bundles do). generate_test_set.sh samples RANDOM
+#     skeletons, not the benchmark equations, so it is NOT a substitute.
+#   * Otherwise train with holdout_pools: [] -- fine for non-benchmark use, but benchmark eval
+#     numbers (e.g. FastSRB/Feynman) will be contaminated until you can decontaminate.
+#   * symbolic_data.load_benchmark('fastsrb') provides the FastSRB benchmark for EVALUATION
+#     (used by srbf); it is an (X, y) sampler and does NOT build a training-holdout pool.
+#
+# Track: https://github.com/psaegert/symbolic-data  (ingest CLI -> symbolic-data 0.2)
 
-# Not currently used
-# flash_ansr import-data -i "{{ROOT}}/data/ansr-data/test_set/soose_nc/nc.csv" -p "soose" -e "dev_7-3" -b "{{ROOT}}/configs/test_set/skeleton_pool.yaml" -o "{{ROOT}}/data/ansr-data/test_set/soose_nc/skeleton_pool" -v
-# flash_ansr import-data -i "{{ROOT}}/data/ansr-data/test_set/feynman/FeynmanEquations.csv" -p "feynman" -e "dev_7-3" -b "{{ROOT}}/configs/test_set/skeleton_pool.yaml" -o "{{ROOT}}/data/ansr-data/test_set/feynman/skeleton_pool" -v
-# flash_ansr import-data -i "{{ROOT}}/data/ansr-data/test_set/nguyen/nguyen.csv" -p "nguyen" -e "dev_7-3" -b "{{ROOT}}/configs/test_set/skeleton_pool.yaml" -o "{{ROOT}}/data/ansr-data/test_set/nguyen/skeleton_pool" -v
+echo "import_test_sets: raw-spec ingest (ParserFactory) is pending symbolic-data 0.2." >&2
+echo "Interim: point holdout_pools: at a pre-built pool (see the comments in this script)." >&2
+exit 1


### PR DESCRIPTION
## What

flash-ansr 0.7 removed the data CLI (`generate-skeleton-pool`, `import-data`, `filter-/split-skeleton-pool`); pool generation/ingest moved to the [symbolic-data](https://github.com/psaegert/symbolic-data) data layer. The training docs and helper scripts still referenced those dropped commands, so a new user following `docs/training.md` hit dead commands.

## Changes
- `scripts/generate_validation_set.sh` / `generate_test_set.sh`: wrap `symbolic_data.SkeletonPool` (`from_config`/`create`/`save`) via the Python API; relative paths from the project root; `set -euo pipefail`; fixed the `# !/bin/bash` typo.
- `scripts/import_test_sets.sh`: the raw-spec ingest (ParserFactory) is **pending symbolic-data 0.2**, so the script prints a notice and `exit 1`, and documents the interim `holdout_pools:` workflow. (`load_benchmark('fastsrb')` is an eval-only (X, y) sampler and does **not** build a training-holdout pool.)
- `docs/training.md`: replaced the `generate-skeleton-pool` block with the verified `symbolic-data` snippet; honest holdout/decontamination framing (no interim command rebuilds a benchmark holdout pool until 0.2); named the removed commands for <=0.6 migrators; noted `scripts/` + `configs/` are repo-only (not shipped in the wheel).

## Out-of-scope hunk (flagged for transparency)
Also fixes a **pre-existing, unrelated** copy-paste bug in the "Launch training" snippet: it was missing line-continuation `\`, so only `flash_ansr train` would run. Included because it is in the same doc and is the most-used command; calling it out so the reviewer is not surprised.

## Verification
- end-to-end pool-gen run against `configs/test/` (creates + saves a pool)
- `pre-commit` clean; `mkdocs build --strict` exit 0; `bash -n` on all scripts + the Launch block
- zero remaining dropped-CLI references; no CI/Makefile caller of the changed scripts
- 3 load-bearing claims independently confirmed: ParserFactory absent in symbolic-data 0.1.0; `load_benchmark('fastsrb')` is eval-only; `holdout_pools:` is the training-exclusion mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)